### PR TITLE
Enforce unique load_factor input

### DIFF
--- a/pycontrails/physics/jet.py
+++ b/pycontrails/physics/jet.py
@@ -544,6 +544,7 @@ def initial_aircraft_mass(
     reserve_fuel_requirements
     aircraft_load_factor
     """
+    load_factor = float(np.unique(load_factor))
     tom = operating_empty_weight + load_factor * max_payload + total_fuel_burn + total_reserve_fuel
     return min(tom, max_takeoff_weight)
 


### PR DESCRIPTION
As defined in the [Vizcon user-guide](https://github.com/theicct/Vizcon), makes modifications to source code to avoid duplicated load_factor inputs:

> ### Modifications to pycontrails source code to avoid bugs
> There is one modifications to the pycontrails source that may be useful for the ICCT's applications:
> 1. If a user specifies payload by using a load_factor for multiple flights (used in pycontrails to determine the initial aircraft mass as the load_factor times the difference between the maximum takeoff weight and the empty weight), the code will throw an error:
> 
>    ```commandline
>      File "/pycontrails/physics/jet.py", line 419, in initial_aircraft_mass
>        return min(tom, max_takeoff_weight)
>    
>    ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
>    ```
>    
>    The fix is to add the following on the line before `tom = operating_empty_weight + load_factor * max_payload + total_fuel_burn + total_reserve_fuel` in `pycontrails/physics/jet.py`:
>    ```python
>    load_factor = float(np.unique(load_factor))
>    ```
>    
>    This will ensure that the load_factor is a single value, and the code will not throw an error. This works even if the load factor values are different for each flight being modeled.